### PR TITLE
Cache method result on the object, not the class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,16 +140,16 @@ export interface MemoizeOption {
 }
 export function CacheMethod (opt: MemoizeOption, store?: CacheStore) {
     return function (target: Object, method: string, descriptor: TypedPropertyDescriptor<any>) {
-        if (!target[ID_SYMBOL]) {
-            target[ID_SYMBOL] = OBJECT_ID++
-        }
-        const objId = target[ID_SYMBOL]
         const usedCacheStore = store || cacheStore
         if (!descriptor.value) {
             throw new Error('decorator only support method')
         }
         const orginMethod = descriptor.value
-        descriptor.value = async function (...args: any[]) {
+        descriptor.value = async function (this: any, ...args: any[]) {
+            if (!this[ID_SYMBOL]) {
+                this[ID_SYMBOL] = OBJECT_ID++
+            }
+            const objId = this[ID_SYMBOL]
             const cacheKey = opt.key ? opt.key.call(this, objId, method, args) : `cache#{ojb_${objId}}#${method}#${JSON.stringify(args)}`
             if (await usedCacheStore.has(cacheKey)) {
                 return usedCacheStore.get(cacheKey)


### PR DESCRIPTION
Hello there!

I'm using a modified version of this in a project of mine! I noticed a big however, that each method is cached per-class, instead of per-object as I expected. `target` below refers to the class, not the instance. It's `descriptor.value` that is run in the context of the object. This fixes the problem for me - thought you might be interested.